### PR TITLE
Amidar frameskip bug closes #63

### DIFF
--- a/ctoybox/toybox/toybox/envs/atari/amidar.py
+++ b/ctoybox/toybox/toybox/envs/atari/amidar.py
@@ -6,15 +6,14 @@ import sys
 
 class AmidarEnv(ToyboxBaseEnv):
 
-    
-    def __init__(self, grayscale=True, alpha=False):
+    def __init__(self, frameskip=(2, 5), repeat_action_probability=0., grayscale=True, alpha=False):
         self._amidar_action_strs = [
             NOOP_STR, FIRE_STR, LEFT_STR, RIGHT_STR, UP_STR, DOWN_STR,
             UPFIRE_STR, DOWNFIRE_STR, LEFTFIRE_STR, RIGHTFIRE_STR
         ]
         self. _amidar_action_ids = [ACTION_LOOKUP[s] for s in self._amidar_action_strs]
 
-        super().__init__(Toybox('amidar', grayscale),
+        super().__init__(Toybox('amidar', grayscale), 'amidar',
             frameskip, repeat_action_probability,
             grayscale=grayscale,
             alpha=alpha,


### PR DESCRIPTION
Addresses #63 
frameskip, repeat_action_probability variables not defined in AmidarEnv init call. 

Tested successfully on gypsum